### PR TITLE
Change Inter-node Routing Metadata

### DIFF
--- a/cfg/online-boutique-concurrency-32.cfg
+++ b/cfg/online-boutique-concurrency-32.cfg
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name = "Online Boutique";
+name = "Online Boutique (Single Node)";
 
 nfs = (
     {
@@ -28,6 +28,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     },
     {
         id = 2;
@@ -40,6 +42,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     },
     {
         id = 3;
@@ -52,6 +56,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     },
     {
         id = 4;
@@ -64,6 +70,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     },
     {
         id = 5;
@@ -76,6 +84,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     },
     {
         id = 6;
@@ -88,6 +98,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     },
     {
         id = 7;
@@ -100,6 +112,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     },
     {
         id = 8;
@@ -112,6 +126,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     },
     {
         id = 9;
@@ -124,6 +140,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     },
     {
         id = 10;
@@ -136,6 +154,8 @@ nfs = (
             sleep_ns = 0;
             compute = 0;
         };
+
+        node = 0;
     }
 );
 
@@ -175,5 +195,15 @@ routes = (
         name = "POST /cart/checkout";
 
         hops = [1, 7, 4, 7, 3, 7, 2, 7, 6, 7, 2, 7, 8, 7, 6, 7, 4, 7, 9, 7, 1, 5, 1, 2, 1];
+    }
+);
+
+nodes = (
+    {
+        id = 0;
+        hostname = "node0.spright.kkprojects-pg0.wisc.cloudlab.us";
+
+        ip_address = "10.10.1.1";
+        port = 8083;
     }
 );

--- a/src/include/io.h
+++ b/src/include/io.h
@@ -27,6 +27,6 @@ int io_exit(void);
 
 int io_rx(void **obj);
 
-int io_tx(void *obj, uint8_t next_node);
+int io_tx(void *obj, uint8_t next_fn);
 
 #endif /* IO_H */

--- a/src/include/utility.h
+++ b/src/include/utility.h
@@ -40,6 +40,8 @@ void PrintSearchProductsResponse(struct http_transaction *txn);
 
 void PrintSupportedCurrencies (struct http_transaction *in);
 void PrintConversionResult(struct http_transaction *in);
+void printMoney(Money *money);
+void printCurrencyConversionRequest(CurrencyConversionRequest *request);
 void MockCurrencyConversionRequest(struct http_transaction *in);
 
 void PrintGetCartResponse(struct http_transaction *txn);

--- a/src/io_rte_ring.c
+++ b/src/io_rte_ring.c
@@ -173,9 +173,9 @@ int io_rx(void **obj)
     return 0;
 }
 
-int io_tx(void *obj, uint8_t next_node)
+int io_tx(void *obj, uint8_t next_fn)
 {
-    while (rte_ring_enqueue(ring[next_node], obj) != 0);
+    while (rte_ring_enqueue(ring[next_fn], obj) != 0);
 
     return 0;
 }

--- a/src/io_sk_msg.c
+++ b/src/io_sk_msg.c
@@ -481,12 +481,12 @@ int io_rx(void **obj)
     return 0;
 }
 
-int io_tx(void *obj, uint8_t next_node)
+int io_tx(void *obj, uint8_t next_fn)
 {
     ssize_t bytes_sent;
     struct metadata m;
 
-    m.fn_id = next_node;
+    m.fn_id = next_fn;
     m.obj = obj;
 
     bytes_sent = send(sockfd_sk_msg, &m, sizeof(struct metadata), 0);

--- a/src/nf.c
+++ b/src/nf.c
@@ -171,7 +171,6 @@ static void *nf_tx(void *arg)
     struct epoll_event event[UINT8_MAX]; /* TODO: Use Macro */
     struct http_transaction *txn = NULL;
     ssize_t bytes_read;
-    uint8_t next_node;
     uint8_t i;
     int n_fds;
     int epfd;
@@ -224,13 +223,18 @@ static void *nf_tx(void *arg)
 
             if (likely(txn->hop_count <
                        cfg->route[txn->route_id].length)) {
-                next_node =
+                txn->next_fn =
                 cfg->route[txn->route_id].hop[txn->hop_count];
             } else {
-                next_node = 0;
+                txn->next_fn = 0;
             }
 
-            ret = io_tx(txn, next_node);
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", txn->route_id,
+                txn->hop_count, cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
+
+            ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {
                 log_error("io_tx() error");
                 return NULL;

--- a/src/online_boutique/adservice.c
+++ b/src/online_boutique/adservice.c
@@ -134,7 +134,6 @@ static void GetAds(struct http_transaction *in) {
     PrintContextKeys(ad_request);
     in->ad_response.num_ads = 0;
 
-    // []*pb.Ad allAds;
     if (ad_request->num_context_keys > 0) {
         log_info("Constructing Ads using received context.");
         int i;
@@ -297,6 +296,12 @@ static void *nf_tx(void *arg)
                         strerror(errno));
                 return NULL;
             }
+
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", 
+                txn->route_id, txn->hop_count,
+                cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
 
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {

--- a/src/online_boutique/cartservice.c
+++ b/src/online_boutique/cartservice.c
@@ -295,7 +295,6 @@ static void *nf_tx(void *arg)
     struct epoll_event event[UINT8_MAX]; /* TODO: Use Macro */
     struct http_transaction *txn = NULL;
     ssize_t bytes_read;
-    // uint8_t next_node;
     uint8_t i;
     int n_fds;
     int epfd;
@@ -344,15 +343,11 @@ static void *nf_tx(void *arg)
                 return NULL;
             }
 
-            // txn->hop_count++;
-
-            // if (likely(txn->hop_count <
-            //            cfg->route[txn->route_id].length)) {
-            // 	next_node =
-            // 	cfg->route[txn->route_id].node[txn->hop_count];
-            // } else {
-            // 	next_node = 0;
-            // }
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", 
+                txn->route_id, txn->hop_count,
+                cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
 
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {

--- a/src/online_boutique/checkoutservice.c
+++ b/src/online_boutique/checkoutservice.c
@@ -412,6 +412,12 @@ static void *nf_tx(void *arg)
                 return NULL;
             }
 
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", 
+                txn->route_id, txn->hop_count,
+                cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
+
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {
                 log_error("io_tx() error");

--- a/src/online_boutique/currencyservice.c
+++ b/src/online_boutique/currencyservice.c
@@ -45,7 +45,7 @@ static int pipefd_tx[UINT8_MAX][2];
 char *currencies[] = {"EUR", "USD", "JPY", "CAD"};
 double conversion_rate[] = {1.0, 1.1305, 126.40, 1.5128};
 
-static int compare_e(void* left, void* right ) {
+static int compare_e(void* left, void* right) {
     return strcmp((const char *)left, (const char *)right);
 }
 
@@ -75,20 +75,10 @@ static void GetSupportedCurrencies(struct http_transaction *in){
         strcpy(in->get_supported_currencies_response.CurrencyCodes[i], currencies[i]);
     }
 
-    // log_info("[GetSupportedCurrencies] completed request");
     return;
 }
 
-// static void PrintSupportedCurrencies (struct http_transaction *in) {
-// 	log_info("Supported Currencies: ");
-// 	int i = 0;
-// 	for (i = 0; i < in->get_supported_currencies_response.num_currencies; i++) {
-// 		log_info("%s\t", in->get_supported_currencies_response.CurrencyCodes[i]);
-// 	}
-// 	printf("\n");
-// }
-
-/**
+/*
  * Helper function that handles decimal/fractional carrying
  */
 static void Carry(Money* amount) {
@@ -103,6 +93,9 @@ static void Convert(struct http_transaction *txn) {
     log_info("[Convert] received request");
     CurrencyConversionRequest* in = &txn->currency_conversion_req;
     Money* euros = &txn->currency_conversion_result;
+
+    // printMoney(euros);
+    // printCurrencyConversionRequest(in);
 
     // Convert: from_currency --> EUR
     void* data;
@@ -251,15 +244,11 @@ static void *nf_tx(void *arg)
                 return NULL;
             }
 
-            // txn->hop_count++;
-
-            // if (likely(txn->hop_count <
-            //            cfg->route[txn->route_id].length)) {
-            // 	next_node =
-            // 	cfg->route[txn->route_id].node[txn->hop_count];
-            // } else {
-            // 	next_node = 0;
-            // }
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", 
+                txn->route_id, txn->hop_count,
+                cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
 
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {
@@ -419,6 +408,7 @@ int main(int argc, char **argv)
 
     currency_data_map = new_c_map(compare_e, NULL, NULL);
     getCurrencyData(currency_data_map);
+
     ret = nf(nf_id);
     if (unlikely(ret == -1)) {
         log_error("nf() error");

--- a/src/online_boutique/emailservice.c
+++ b/src/online_boutique/emailservice.c
@@ -169,6 +169,12 @@ static void *nf_tx(void *arg)
                 return NULL;
             }
 
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", 
+                txn->route_id, txn->hop_count,
+                cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
+
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {
                 log_error("io_tx() error");

--- a/src/online_boutique/frontendservice.c
+++ b/src/online_boutique/frontendservice.c
@@ -77,7 +77,7 @@ static void homeHandler(struct http_transaction *txn) {
         returnResponse(txn);
 
     } else {
-        log_info("homeHandler doesn't know what to do for HOP %u.", txn->hop_count);
+        log_warn("homeHandler doesn't know what to do for HOP %u.", txn->hop_count);
         returnResponse(txn);
 
     }
@@ -102,7 +102,7 @@ static void productHandler(struct http_transaction *txn) {
     } else if (txn->hop_count == 5) {
         returnResponse(txn);
     } else {
-        log_info("productHandler doesn't know what to do for HOP %u.", txn->hop_count);
+        log_warn("productHandler doesn't know what to do for HOP %u.", txn->hop_count);
         returnResponse(txn);
 
     }
@@ -285,7 +285,6 @@ static void *nf_tx(void *arg)
     struct epoll_event event[UINT8_MAX]; /* TODO: Use Macro */
     struct http_transaction *txn = NULL;
     ssize_t bytes_read;
-    // uint8_t next_node;
     uint8_t i;
     int n_fds;
     int epfd;
@@ -333,6 +332,12 @@ static void *nf_tx(void *arg)
                         strerror(errno));
                 return NULL;
             }
+
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", 
+                txn->route_id, txn->hop_count,
+                cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
 
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {

--- a/src/online_boutique/paymentservice.c
+++ b/src/online_boutique/paymentservice.c
@@ -270,6 +270,12 @@ static void *nf_tx(void *arg)
                 return NULL;
             }
 
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", 
+                txn->route_id, txn->hop_count,
+                cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
+
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {
                 log_error("io_tx() error");

--- a/src/online_boutique/productcatalogservice.c
+++ b/src/online_boutique/productcatalogservice.c
@@ -375,7 +375,12 @@ static void *nf_tx(void *arg)
                 return NULL;
             }
 
-            // log_info("receive msg");
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", 
+                txn->route_id, txn->hop_count,
+                cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
+
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {
                 log_error("io_tx() error");

--- a/src/online_boutique/recommendationservice.c
+++ b/src/online_boutique/recommendationservice.c
@@ -314,6 +314,12 @@ static void *nf_tx(void *arg)
                 return NULL;
             }
 
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u, \
+                Caller Fn: %s (#%u), RPC Handler: %s()", 
+                txn->route_id, txn->hop_count,
+                cfg->route[txn->route_id].hop[txn->hop_count],
+                txn->next_fn, txn->caller_nf, txn->caller_fn, txn->rpc_handler);
+
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {
                 log_error("io_tx() error");

--- a/src/online_boutique/shippingservice.c
+++ b/src/online_boutique/shippingservice.c
@@ -303,6 +303,11 @@ static void *nf_tx(void *arg)
                 return NULL;
             }
 
+            log_debug("Route id: %u, Hop Count %u, Next Hop: %u, Next Fn: %u", 
+                    txn->route_id, txn->hop_count,
+                    cfg->route[txn->route_id].hop[txn->hop_count],
+                    txn->next_fn);
+
             ret = io_tx(txn, txn->next_fn);
             if (unlikely(ret == -1)) {
                 log_error("io_tx() error");

--- a/src/shm_rpc.c
+++ b/src/shm_rpc.c
@@ -113,11 +113,9 @@ void getProduct(struct http_transaction *txn) {
     char *req = txn->request;
 
     if (strstr(req, "/1/cart?") != NULL && strstr(req, "POST")) {
-        // log_info("Query : %s", query);
         char *start_of_product_id = strtok(query, "&");
         strcpy(txn->get_product_request.Id, strchr(start_of_product_id, '=') + 1);
         log_info("Product ID: %s", txn->get_product_request.Id);
-        // product_id=66VCHSJNUP&quantity=1
         // returnResponse(txn); return;
     } else if (strstr(req, "/1/product") != NULL) {
         strcpy(txn->get_product_request.Id, query);

--- a/src/utility.c
+++ b/src/utility.c
@@ -124,6 +124,19 @@ void PrintConversionResult(struct http_transaction *in) {
     log_info("Value: %ld.%d", in->currency_conversion_result.Units, in->currency_conversion_result.Nanos);
 }
 
+void printMoney(Money *money) {
+    printf("Money:\n");
+    printf("  Currency Code: %s\n", money->CurrencyCode);
+    printf("  Units: %ld\n", money->Units);
+    printf("  Nanos: %d\n", money->Nanos);
+}
+
+void printCurrencyConversionRequest(CurrencyConversionRequest *request) {
+    printf("Currency Conversion Request:\n");
+    printMoney(&request->From);
+    printf("  To Currency Code: %s\n", request->ToCode);
+}
+
 void MockCurrencyConversionRequest(struct http_transaction *in) {
     strcpy(in->currency_conversion_req.ToCode, "USD");
     strcpy(in->currency_conversion_req.From.CurrencyCode, "EUR");
@@ -265,13 +278,18 @@ void parsePlaceOrderRequest(struct http_transaction *txn) {
 }
 
 char* httpQueryParser(char* req) {
-    char tmp[600]; strcpy(tmp, req);
+    char tmp[600];
+    strcpy(tmp, req);
 
     char *start_of_path = strtok(tmp, " ");
     start_of_path = strtok(NULL, " ");
-       // log_info("%s", start_of_path); //printing the token
     char *start_of_query = strchr(start_of_path, '?') + 1;
-    // log_info("%s", start_of_query); //product_id=66VCHSJNUP&quantity=1
+
+    // Remove trailing slash if present
+    size_t len = strlen(start_of_query);
+    if (start_of_query[len - 1] == '/') {
+        start_of_query[len - 1] = '\0';
+    }
 
     return start_of_query;
 }


### PR DESCRIPTION
This PR uses "[next_fn](https://github.com/ucr-serverless/spright/blob/65c1fc8e441c4c57fd2376d56c46eed504464908/src/include/http.h#L230)" in [struct http_transaction](https://github.com/ucr-serverless/spright/blob/65c1fc8e441c4c57fd2376d56c46eed504464908/src/include/http.h#L227C1-L227C24) for the routing between functions instead of using "[hop_count](https://github.com/ucr-serverless/spright/blob/65c1fc8e441c4c57fd2376d56c46eed504464908/src/include/http.h#L231C13-L231C22)".

