### PR TITLE
Launch RPC client and RPC server on separate lcores

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 CPU_SHM_MGR=(0)
-CPU_GATEWAY=(0 1 2 3)
-CPU_NF=(4 5 6 7 8 9 20 21 22 23 24 25 26 27 28 29)
+CPU_GATEWAY=(0 1 2 3 4)
+CPU_NF=(5 6 7 8 9 20 21 22 23 24 25 26 27 28 29)
 
 if [ ${EUID} -ne 0 ]
 then
@@ -43,7 +43,7 @@ shm_mgr()
 gateway()
 {
 	exec bin/gateway_${io} \
-		-l ${CPU_GATEWAY[0]},${CPU_GATEWAY[1]},${CPU_GATEWAY[2]},${CPU_GATEWAY[3]} \
+		-l ${CPU_GATEWAY[0]},${CPU_GATEWAY[1]},${CPU_GATEWAY[2]},${CPU_GATEWAY[3]},${CPU_GATEWAY[4]} \
 		--main-lcore=${CPU_GATEWAY[0]} \
 		--file-prefix=spright \
 		--proc-type=secondary \

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 CPU_SHM_MGR=(0)
-CPU_GATEWAY=(0 1 2)
-CPU_NF=(3 4 5 6 7 8 9 20 21 22 23 24 25 26 27 28 29)
+CPU_GATEWAY=(0 1 2 3)
+CPU_NF=(4 5 6 7 8 9 20 21 22 23 24 25 26 27 28 29)
 
 if [ ${EUID} -ne 0 ]
 then
@@ -43,7 +43,7 @@ shm_mgr()
 gateway()
 {
 	exec bin/gateway_${io} \
-		-l ${CPU_GATEWAY[0]},${CPU_GATEWAY[1]},${CPU_GATEWAY[2]} \
+		-l ${CPU_GATEWAY[0]},${CPU_GATEWAY[1]},${CPU_GATEWAY[2]},${CPU_GATEWAY[3]} \
 		--main-lcore=${CPU_GATEWAY[0]} \
 		--file-prefix=spright \
 		--proc-type=secondary \

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -332,10 +332,9 @@ static int rpc_client_setup(char *server_ip, uint16_t server_port, uint8_t peer_
     server_addr.sin_port = htons(server_port);
     server_addr.sin_addr.s_addr = inet_addr(server_ip);
 
-    ret = connect(sockfd, (struct sockaddr *)&server_addr,
-                  sizeof(struct sockaddr_in));
+    ret = retry_connect(sockfd, (struct sockaddr *)&server_addr);
     if (unlikely(ret == -1)) {
-        log_error("connect() error: %s", strerror(errno));
+        log_error("connect() failed: %s", strerror(errno));
         return -1;
     }
 
@@ -380,7 +379,7 @@ static int rpc_client_send(int peer_node_idx, struct http_transaction *txn) {
 // 	return 0;
 // }
 
-void* rpc_client_thread(void* arg) {
+int rpc_client_thread(void* arg) {
     int epoll_fd;
     struct epoll_event ev, events[N_EVENTS_MAX];
     int nfds;
@@ -388,13 +387,13 @@ void* rpc_client_thread(void* arg) {
 
     epoll_fd = epoll_create1(0);
     if (epoll_fd == -1) {
-        perror("epoll_create1");
+        log_error("epoll_create1() error: %s", strerror(errno));
         exit(EXIT_FAILURE);
     }
 
     ret = add_pipes_to_epoll(epoll_fd, &ev);
     if (ret == -1) {
-        return NULL;
+        return ret;
     }
 
     int gcd_weight = get_gcd_weight();
@@ -444,7 +443,7 @@ void* rpc_client_thread(void* arg) {
                                    INTERNAL_SERVER_PORT, peer_node_idx);
                     } else if (peer_node_sockfds[peer_node_idx] < 0) {
                         log_error("Invalid socket error.");
-                        return NULL;
+                        return -1;
                     }
 
                     ret = rpc_client_send(peer_node_idx, txn);
@@ -458,7 +457,7 @@ void* rpc_client_thread(void* arg) {
     }
 
     close(epoll_fd);
-    return NULL;
+    return -1;
 }
 
 static int conn_accept(struct server_vars *sv)
@@ -691,7 +690,6 @@ static int server_init(struct server_vars *sv)
     int rpc_svr_epfd;
     pthread_t rpc_svr_setup_thread;
     pthread_t rpc_svr_recv_thread;
-    pthread_t rpc_clt_thread;
 
     log_info("Initializing intra-node I/O...");
     ret = io_init();
@@ -718,12 +716,6 @@ static int server_init(struct server_vars *sv)
     }
 
     ret = pthread_create(&rpc_svr_recv_thread, NULL, &rpc_server_receive_thread, &rpc_svr_epfd);
-    if (unlikely(ret != 0)) {
-        log_error("pthread_create() error: %s", strerror(ret));
-        return -1;
-    }
-
-    ret = pthread_create(&rpc_clt_thread, NULL, &rpc_client_thread, NULL);
     if (unlikely(ret != 0)) {
         log_error("pthread_create() error: %s", strerror(ret));
         return -1;
@@ -882,7 +874,7 @@ static void metrics_collect(void)
 static int gateway(void)
 {
     const struct rte_memzone *memzone = NULL;
-    unsigned int lcore_worker[2];
+    unsigned int lcore_worker[3];
     struct server_vars sv;
     int ret;
     memset(peer_node_sockfds, 0, sizeof(peer_node_sockfds));
@@ -915,6 +907,12 @@ static int gateway(void)
         goto error_1;
     }
 
+    lcore_worker[2] = rte_get_next_lcore(lcore_worker[1], 1, 1);
+    if (unlikely(lcore_worker[1] == RTE_MAX_LCORE)) {
+        log_error("rte_get_next_lcore() error");
+        goto error_1;
+    }
+
     ret = rte_eal_remote_launch(server_process_rx, &sv, lcore_worker[0]);
     if (unlikely(ret < 0)) {
         log_error("rte_eal_remote_launch() error: %s",
@@ -923,6 +921,13 @@ static int gateway(void)
     }
 
     ret = rte_eal_remote_launch(server_process_tx, &sv, lcore_worker[1]);
+    if (unlikely(ret < 0)) {
+        log_error("rte_eal_remote_launch() error: %s",
+                rte_strerror(-ret));
+        goto error_1;
+    }
+
+    ret = rte_eal_remote_launch(rpc_client_thread, NULL, lcore_worker[2]);
     if (unlikely(ret < 0)) {
         log_error("rte_eal_remote_launch() error: %s",
                 rte_strerror(-ret));
@@ -938,6 +943,12 @@ static int gateway(void)
     }
 
     ret = rte_eal_wait_lcore(lcore_worker[1]);
+    if (unlikely(ret == -1)) {
+        log_error("server_process_tx() error");
+        goto error_1;
+    }
+
+    ret = rte_eal_wait_lcore(lcore_worker[2]);
     if (unlikely(ret == -1)) {
         log_error("server_process_tx() error");
         goto error_1;

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -302,6 +302,36 @@ void* rpc_server_receive_thread(void* arg) {
     return NULL;
 }
 
+int rpc_server(void* arg) {
+    int rpc_svr_epfd;
+    int ret;
+    pthread_t rpc_svr_setup_thread;
+    pthread_t rpc_svr_recv_thread;
+
+    rpc_svr_epfd = epoll_create1(0);
+    if (unlikely(rpc_svr_epfd == -1)) {
+        log_error("epoll_create1() error: %s", strerror(errno));
+        return -1;
+    }
+
+    ret = pthread_create(&rpc_svr_setup_thread, NULL, &rpc_server_setup_thread, &rpc_svr_epfd);
+    if (unlikely(ret != 0)) {
+        log_error("pthread_create() error: %s", strerror(ret));
+        return -1;
+    }
+
+    ret = pthread_create(&rpc_svr_recv_thread, NULL, &rpc_server_receive_thread, &rpc_svr_epfd);
+    if (unlikely(ret != 0)) {
+        log_error("pthread_create() error: %s", strerror(ret));
+        return -1;
+    }
+
+    pthread_join(rpc_svr_setup_thread, NULL);
+    pthread_join(rpc_svr_recv_thread, NULL);
+
+    return 0;
+}
+
 static int rpc_client_setup(char *server_ip, uint16_t server_port, uint8_t peer_node_idx) {
     log_info("RPC client connects with node %u (%s:%u).", peer_node_idx,
             cfg->nodes[peer_node_idx].ip_address, INTERNAL_SERVER_PORT);
@@ -379,7 +409,7 @@ static int rpc_client_send(int peer_node_idx, struct http_transaction *txn) {
 // 	return 0;
 // }
 
-int rpc_client_thread(void* arg) {
+int rpc_client(void* arg) {
     int epoll_fd;
     struct epoll_event ev, events[N_EVENTS_MAX];
     int nfds;
@@ -687,9 +717,6 @@ static int server_init(struct server_vars *sv)
     struct epoll_event event;
     int optval;
     int ret;
-    int rpc_svr_epfd;
-    pthread_t rpc_svr_setup_thread;
-    pthread_t rpc_svr_recv_thread;
 
     log_info("Initializing intra-node I/O...");
     ret = io_init();
@@ -700,24 +727,6 @@ static int server_init(struct server_vars *sv)
 
     ret = init_tenant_pipes();
     if (unlikely(ret == -1)) {
-        return -1;
-    }
-
-    rpc_svr_epfd = epoll_create1(0);
-    if (unlikely(rpc_svr_epfd == -1)) {
-        log_error("epoll_create1() error: %s", strerror(errno));
-        return -1;
-    }
-
-    ret = pthread_create(&rpc_svr_setup_thread, NULL, &rpc_server_setup_thread, &rpc_svr_epfd);
-    if (unlikely(ret != 0)) {
-        log_error("pthread_create() error: %s", strerror(ret));
-        return -1;
-    }
-
-    ret = pthread_create(&rpc_svr_recv_thread, NULL, &rpc_server_receive_thread, &rpc_svr_epfd);
-    if (unlikely(ret != 0)) {
-        log_error("pthread_create() error: %s", strerror(ret));
         return -1;
     }
 
@@ -874,7 +883,7 @@ static void metrics_collect(void)
 static int gateway(void)
 {
     const struct rte_memzone *memzone = NULL;
-    unsigned int lcore_worker[3];
+    unsigned int lcore_worker[4];
     struct server_vars sv;
     int ret;
     memset(peer_node_sockfds, 0, sizeof(peer_node_sockfds));
@@ -913,6 +922,12 @@ static int gateway(void)
         goto error_1;
     }
 
+    lcore_worker[3] = rte_get_next_lcore(lcore_worker[2], 1, 1);
+    if (unlikely(lcore_worker[1] == RTE_MAX_LCORE)) {
+        log_error("rte_get_next_lcore() error");
+        goto error_1;
+    }
+
     ret = rte_eal_remote_launch(server_process_rx, &sv, lcore_worker[0]);
     if (unlikely(ret < 0)) {
         log_error("rte_eal_remote_launch() error: %s",
@@ -927,7 +942,14 @@ static int gateway(void)
         goto error_1;
     }
 
-    ret = rte_eal_remote_launch(rpc_client_thread, NULL, lcore_worker[2]);
+    ret = rte_eal_remote_launch(rpc_client, NULL, lcore_worker[2]);
+    if (unlikely(ret < 0)) {
+        log_error("rte_eal_remote_launch() error: %s",
+                rte_strerror(-ret));
+        goto error_1;
+    }
+
+    ret = rte_eal_remote_launch(rpc_server, NULL, lcore_worker[3]);
     if (unlikely(ret < 0)) {
         log_error("rte_eal_remote_launch() error: %s",
                 rte_strerror(-ret));
@@ -950,7 +972,13 @@ static int gateway(void)
 
     ret = rte_eal_wait_lcore(lcore_worker[2]);
     if (unlikely(ret == -1)) {
-        log_error("server_process_tx() error");
+        log_error("rpc_client() error");
+        goto error_1;
+    }
+
+    ret = rte_eal_wait_lcore(lcore_worker[3]);
+    if (unlikely(ret == -1)) {
+        log_error("rpc_server() error");
         goto error_1;
     }
 

--- a/src/include/io.h
+++ b/src/include/io.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <fcntl.h>
 #include <sys/epoll.h>
+#include <sys/socket.h>
 
 #include "spright.h"
 #include "log.h"
@@ -55,5 +56,7 @@ int write_pipe(struct http_transaction *txn);
 struct http_transaction* read_pipe(tenant_pipe *tp);
 int add_pipes_to_epoll(int epoll_fd, struct epoll_event *ev);
 ssize_t read_full(int fd, void *buf, size_t count);
+
+int retry_connect(int sockfd, struct sockaddr *addr);
 
 #endif /* IO_H */


### PR DESCRIPTION
This PR is to launch RPC client in the SPRIGHT gateway on a different lcore. The RPC client in the SPRIGHT gateway is responsible for inter-node communication (transmit). To improve the performance of the RPC client thread, we assign it with a dedicated CPU core, using `rte_eal_remote_launch()`.