### PR TITLE
Remove Multiple Definitions of Variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CLANG = clang
 CLANGFLAGS = -g -O2
 BPF_FLAGS = -target bpf
 
-COMMON_OBJS = src/log/log.o src/utility.o src/timer.o src/io_helper.o
+COMMON_OBJS = src/log/log.o src/utility.o src/timer.o src/io_helper.o src/common.o
 
 .PHONY: all shm_mgr gateway nf clean
 

--- a/src/common.c
+++ b/src/common.c
@@ -1,0 +1,20 @@
+/*
+# Copyright 2024 University of California, Riverside
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+int fn_id;
+struct spright_cfg_s *cfg;

--- a/src/include/common.h
+++ b/src/include/common.h
@@ -1,0 +1,27 @@
+/*
+# Copyright 2024 University of California, Riverside
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+*/
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#include "spright.h"
+
+extern int fn_id;
+extern struct spright_cfg_s *cfg;
+
+#endif /* COMMON_H */

--- a/src/include/io.h
+++ b/src/include/io.h
@@ -27,6 +27,7 @@
 #include "spright.h"
 #include "log.h"
 #include "http.h"
+#include "common.h"
 
 #define MAX_TENANTS (1U << 8)
 #define N_EVENTS_MAX (1U << 17)
@@ -37,7 +38,7 @@ typedef struct {
     uint32_t tenant_id;
 } tenant_pipe;
 
-tenant_pipe tenant_pipes[MAX_TENANTS];
+extern tenant_pipe tenant_pipes[MAX_TENANTS];
 
 int io_init(void);
 

--- a/src/include/shm_rpc.h
+++ b/src/include/shm_rpc.h
@@ -22,7 +22,7 @@
 #include "http.h"
 #include "utility.h"
 
-char defaultCurrency[5];
+extern char defaultCurrency[5];
 
 void chooseAd(struct http_transaction *txn);
 

--- a/src/include/spright.h
+++ b/src/include/spright.h
@@ -33,9 +33,7 @@
 #define EXTERNAL_SERVER_PORT 8080
 #define INTERNAL_SERVER_PORT 8084
 
-int fn_id;
-
-struct {
+struct spright_cfg_s {
     struct rte_mempool *mempool;
 
     char name[64];
@@ -78,6 +76,6 @@ struct {
     } nodes[UINT8_MAX + 1];
 
     uint8_t inter_node_rt[ROUTING_TABLE_SIZE];
-} *cfg;
+};
 
 #endif /* SPRIGHT_H */

--- a/src/io_helper.c
+++ b/src/io_helper.c
@@ -35,6 +35,8 @@
 #define MAX_RETRIES 5
 #define RETRY_DELAY_US 5000 // 5 milliseconds
 
+tenant_pipe tenant_pipes[MAX_TENANTS];
+
 /*
  * Calculate the Greatest Common Divisor
  */


### PR DESCRIPTION
This PR is to remove multiple definitions of the same variables across different object files. This PR resolves this issue by ensuring that variables are declared as extern in the header files and defined only once in a single source file.