### PR TITLE
Improving The Threading Model in SPRIGHT Gateway

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 CPU_SHM_MGR=(0)
-CPU_GATEWAY=(0 1 2 3 4)
-CPU_NF=(5 6 7 8 9 20 21 22 23 24 25 26 27 28 29)
+CPU_GATEWAY=(0 1 2 3 4 5)
+CPU_NF=(6 7 8 9 20 21 22 23 24 25 26 27 28 29)
 
 if [ ${EUID} -ne 0 ]
 then
@@ -43,7 +43,7 @@ shm_mgr()
 gateway()
 {
 	exec bin/gateway_${io} \
-		-l ${CPU_GATEWAY[0]},${CPU_GATEWAY[1]},${CPU_GATEWAY[2]},${CPU_GATEWAY[3]},${CPU_GATEWAY[4]} \
+		-l ${CPU_GATEWAY[0]},${CPU_GATEWAY[1]},${CPU_GATEWAY[2]},${CPU_GATEWAY[3]},${CPU_GATEWAY[4]},${CPU_GATEWAY[5]} \
 		--main-lcore=${CPU_GATEWAY[0]} \
 		--file-prefix=spright \
 		--proc-type=secondary \

--- a/scripts/microbench/pipe_latency_multithreads.c
+++ b/scripts/microbench/pipe_latency_multithreads.c
@@ -1,0 +1,126 @@
+// Qi: This is a simple benchmark that measures the latency 
+// introduced by using a Linux pipe for data transmission
+// $ gcc -o pipe_latency_multithreads pipe_latency_multithreads.c -lpthread
+// $ ./pipe_latency_multithreads
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <string.h>
+#include <pthread.h>
+
+#define MIN_DATA_SIZE 8   // Minimum data size
+#define MAX_DATA_SIZE 8192  // Maximum data size
+#define NUM_ITERATIONS 20  // Number of iterations for each data size
+
+typedef struct {
+    int data_size;
+    int pipe_fds[2];
+} thread_data_t;
+
+void error_exit(const char *message) {
+    perror(message);
+    exit(EXIT_FAILURE);
+}
+
+void* writer_thread(void* arg) {
+    thread_data_t* data = (thread_data_t*)arg;
+    char* buffer = (char*)malloc(data->data_size);
+    if (buffer == NULL) {
+        error_exit("malloc failed");
+    }
+    memset(buffer, 'A', data->data_size);
+
+    // Write data to the pipe
+    if (write(data->pipe_fds[1], buffer, data->data_size) == -1) {
+        free(buffer);
+        error_exit("write failed");
+    }
+
+    free(buffer);
+    return NULL;
+}
+
+void* reader_thread(void* arg) {
+    thread_data_t* data = (thread_data_t*)arg;
+    char* buffer = (char*)malloc(data->data_size);
+    if (buffer == NULL) {
+        error_exit("malloc failed");
+    }
+
+    // Read data from the pipe
+    if (read(data->pipe_fds[0], buffer, data->data_size) == -1) {
+        free(buffer);
+        error_exit("read failed");
+    }
+
+    free(buffer);
+    return NULL;
+}
+
+long measure_latency(int data_size) {
+    pthread_t writer, reader;
+    thread_data_t thread_data;
+    struct timeval start_time, end_time;
+    long latency;
+
+    // Initialize pipe and thread data
+    thread_data.data_size = data_size;
+    if (pipe(thread_data.pipe_fds) == -1) {
+        error_exit("pipe failed");
+    }
+
+    // Get the start time
+    if (gettimeofday(&start_time, NULL) == -1) {
+        error_exit("gettimeofday failed");
+    }
+
+    // Create writer and reader threads
+    if (pthread_create(&writer, NULL, writer_thread, &thread_data) != 0) {
+        error_exit("pthread_create writer failed");
+    }
+    if (pthread_create(&reader, NULL, reader_thread, &thread_data) != 0) {
+        error_exit("pthread_create reader failed");
+    }
+
+    // Wait for both threads to complete
+    pthread_join(writer, NULL);
+    pthread_join(reader, NULL);
+
+    // Get the end time
+    if (gettimeofday(&end_time, NULL) == -1) {
+        error_exit("gettimeofday failed");
+    }
+
+    // Calculate the latency in microseconds
+    latency = (end_time.tv_sec - start_time.tv_sec) * 1000000L +
+              (end_time.tv_usec - start_time.tv_usec);
+
+    // Close the pipe
+    close(thread_data.pipe_fds[0]);
+    close(thread_data.pipe_fds[1]);
+
+    return latency;
+}
+
+int main() {
+    int data_size;
+    long total_latency, average_latency;
+
+    printf("Data Size (bytes)\tAverage Latency (microseconds)\n");
+
+    for (data_size = MIN_DATA_SIZE; data_size <= MAX_DATA_SIZE; data_size *= 2) {
+        total_latency = 0;
+
+        for (int i = 0; i < NUM_ITERATIONS; i++) {
+            total_latency += measure_latency(data_size);
+        }
+
+        average_latency = total_latency / NUM_ITERATIONS;
+
+        printf("%d\t\t\t%ld\n", data_size, average_latency);
+    }
+
+    return 0;
+}

--- a/scripts/microbench/pipe_latency_singlethread.c
+++ b/scripts/microbench/pipe_latency_singlethread.c
@@ -1,0 +1,87 @@
+// Qi: This is a simple benchmark that measures the latency 
+// introduced by using a Linux pipe for data transmission
+// $ gcc -o pipe_latency_singlethread pipe_latency_singlethread.c
+// $ ./pipe_latency_singlethread
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/time.h>
+#include <string.h>
+
+#define MIN_DATA_SIZE 8   // Minimum data size
+#define MAX_DATA_SIZE 8192  // Maximum data size
+#define NUM_ITERATIONS 20  // Number of iterations for each data size
+
+void error_exit(const char *message) {
+    perror(message);
+    exit(EXIT_FAILURE);
+}
+
+long measure_latency(int data_size) {
+    int pipe_fds[2];
+    char *data = (char *)malloc(data_size);
+    struct timeval start_time, end_time;
+    long latency;
+
+    if (data == NULL) {
+        error_exit("malloc failed");
+    }
+
+    memset(data, 'A', data_size);
+
+    if (pipe(pipe_fds) == -1) {
+        free(data);
+        error_exit("pipe failed");
+    }
+
+    if (gettimeofday(&start_time, NULL) == -1) {
+        free(data);
+        error_exit("gettimeofday failed");
+    }
+
+    if (write(pipe_fds[1], data, data_size) == -1) {
+        free(data);
+        error_exit("write failed");
+    }
+
+    if (read(pipe_fds[0], data, data_size) == -1) {
+        free(data);
+        error_exit("read failed");
+    }
+
+    if (gettimeofday(&end_time, NULL) == -1) {
+        free(data);
+        error_exit("gettimeofday failed");
+    }
+
+    latency = (end_time.tv_sec - start_time.tv_sec) * 1000000L +
+              (end_time.tv_usec - start_time.tv_usec);
+
+    free(data);
+    close(pipe_fds[0]);
+    close(pipe_fds[1]);
+
+    return latency;
+}
+
+int main() {
+    int data_size;
+    long total_latency, average_latency;
+
+    printf("Data Size (bytes)\tAverage Latency (microseconds)\n");
+
+    for (data_size = MIN_DATA_SIZE; data_size <= MAX_DATA_SIZE; data_size *= 2) {
+        total_latency = 0;
+
+        for (int i = 0; i < NUM_ITERATIONS; i++) {
+            total_latency += measure_latency(data_size);
+        }
+
+        average_latency = total_latency / NUM_ITERATIONS;
+
+        printf("%d\t\t\t%ld\n", data_size, average_latency);
+    }
+
+    return 0;
+}

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -917,13 +917,13 @@ static int gateway(void)
     }
 
     lcore_worker[2] = rte_get_next_lcore(lcore_worker[1], 1, 1);
-    if (unlikely(lcore_worker[1] == RTE_MAX_LCORE)) {
+    if (unlikely(lcore_worker[2] == RTE_MAX_LCORE)) {
         log_error("rte_get_next_lcore() error");
         goto error_1;
     }
 
     lcore_worker[3] = rte_get_next_lcore(lcore_worker[2], 1, 1);
-    if (unlikely(lcore_worker[1] == RTE_MAX_LCORE)) {
+    if (unlikely(lcore_worker[3] == RTE_MAX_LCORE)) {
         log_error("rte_get_next_lcore() error");
         goto error_1;
     }

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -53,6 +53,15 @@ struct server_vars {
     int epfd;
 };
 
+// pipe between dispatcher and rpc_server thread
+static int pipefd_dispatcher__rpc_server[2];
+
+// pipe between dispatcher and server_process_rx thread
+static int pipefd_dispatcher__svr_ps_rx[2];
+
+// pipe between dispatcher and server_process_tx thread
+static int pipefd_dispatcher__svr_ps_tx[2];
+
 int peer_node_sockfds[ROUTING_TABLE_SIZE];
 
 static void configure_keepalive(int sockfd) {
@@ -147,6 +156,72 @@ static int get_client_info(int client_socket, char* ip_addr, int ip_addr_len) {
 #endif
 
     return client_port;
+}
+
+int dispatcher(void* arg) {
+    int epoll_fd;
+    struct epoll_event ev, events[N_EVENTS_MAX];
+    int nfds;
+    int ret;
+    struct http_transaction *txn = NULL;
+    ssize_t bytes_read;
+
+    epoll_fd = epoll_create1(0);
+    if (epoll_fd == -1) {
+        log_error("epoll_create1() error: %s", strerror(errno));
+        exit(EXIT_FAILURE);
+    }
+
+    ret = add_regular_pipe_to_epoll(epoll_fd, &ev, pipefd_dispatcher__rpc_server[0]);
+    if (ret == -1) {
+        return ret;
+    }
+    ret = add_regular_pipe_to_epoll(epoll_fd, &ev, pipefd_dispatcher__svr_ps_rx[0]);
+    if (ret == -1) {
+        return ret;
+    }
+    ret = add_regular_pipe_to_epoll(epoll_fd, &ev, pipefd_dispatcher__svr_ps_tx[0]);
+    if (ret == -1) {
+        return ret;
+    }
+
+    while (1) {
+        nfds = epoll_wait(epoll_fd, events, N_EVENTS_MAX, -1);
+        if (nfds == -1) {
+            log_error("epoll_wait() error: %s", strerror(errno));
+            exit(EXIT_FAILURE);
+        }
+
+        for (int i = 0; i < nfds; i++) {
+            bytes_read = read(events[i].data.fd, &txn,
+                              sizeof(struct http_transaction *));
+            if (unlikely(bytes_read == -1)) {
+                log_error("read() error: %s",
+                        strerror(errno));
+                return -1;
+            }
+
+            if (txn->next_fn != cfg->route[txn->route_id].hop[txn->hop_count]) {
+                if (txn->hop_count == 0){
+                    txn->next_fn = cfg->route[txn->route_id].hop[txn->hop_count];
+                }
+                else {
+                    log_error("Next Function Not Valid!");
+                    return -1;
+                }
+            }
+
+            ret = io_tx(txn, txn->next_fn);
+            if (unlikely(ret == -1)) {
+                log_error("io_tx() error");
+                return -1;
+            }
+
+        }
+    }
+
+    close(epoll_fd);
+    return -1;
 }
 
 static int rpc_server_setup(int epfd) {
@@ -267,9 +342,10 @@ static int rpc_server_receive(int epfd) {
                         txn->route_id, txn->hop_count,
                         cfg->route[txn->route_id].hop[txn->hop_count],
                         txn->next_fn);
-            ret = io_tx(txn, txn->next_fn);
-            if (unlikely(ret == -1)) {
-                log_error("io_tx() error");
+            ssize_t bytes_written = write(pipefd_dispatcher__rpc_server[1], &txn,
+                                    sizeof(struct http_transaction*));
+            if (unlikely(bytes_written == -1)) {
+                log_error("write() error: %s", strerror(errno));
                 goto error_1;
             }
         }
@@ -421,7 +497,7 @@ int rpc_client(void* arg) {
         exit(EXIT_FAILURE);
     }
 
-    ret = add_pipes_to_epoll(epoll_fd, &ev);
+    ret = add_weighted_pipes_to_epoll(epoll_fd, &ev);
     if (ret == -1) {
         return ret;
     }
@@ -584,9 +660,10 @@ static int conn_read(int sockfd)
 
     txn->hop_count = 0;
 
-    ret = io_tx(txn, cfg->route[txn->route_id].hop[0]);
-    if (unlikely(ret == -1)) {
-        log_error("io_tx() error");
+    ssize_t bytes_written = write(pipefd_dispatcher__svr_ps_rx[1], &txn,
+                            sizeof(struct http_transaction*));
+    if (unlikely(bytes_written == -1)) {
+        log_error("write() error: %s", strerror(errno));
         goto error_1;
     }
 
@@ -630,9 +707,10 @@ static int conn_write(int *sockfd)
 
     // Intra-node Communication
     if (txn->hop_count < cfg->route[txn->route_id].length) {
-        ret = io_tx(txn, txn->next_fn);
-        if (unlikely(ret == -1)) {
-            log_error("io_tx() error");
+        ssize_t bytes_written = write(pipefd_dispatcher__svr_ps_tx[1], &txn,
+                                sizeof(struct http_transaction*));
+        if (unlikely(bytes_written == -1)) {
+            log_error("write() error: %s", strerror(errno));
             goto error_1;
         }
 
@@ -883,10 +961,28 @@ static void metrics_collect(void)
 static int gateway(void)
 {
     const struct rte_memzone *memzone = NULL;
-    unsigned int lcore_worker[4];
+    unsigned int lcore_worker[5];
     struct server_vars sv;
     int ret;
     memset(peer_node_sockfds, 0, sizeof(peer_node_sockfds));
+
+    ret = pipe(pipefd_dispatcher__rpc_server);
+    if (unlikely(ret == -1)) {
+        log_error("pipe() error: %s", strerror(errno));
+        goto error_1;
+    }
+
+    ret = pipe(pipefd_dispatcher__svr_ps_rx);
+    if (unlikely(ret == -1)) {
+        log_error("pipe() error: %s", strerror(errno));
+        goto error_1;
+    }
+
+    ret = pipe(pipefd_dispatcher__svr_ps_tx);
+    if (unlikely(ret == -1)) {
+        log_error("pipe() error: %s", strerror(errno));
+        goto error_1;
+    }
 
     fn_id = 0;
 
@@ -928,6 +1024,12 @@ static int gateway(void)
         goto error_1;
     }
 
+    lcore_worker[4] = rte_get_next_lcore(lcore_worker[3], 1, 1);
+    if (unlikely(lcore_worker[4] == RTE_MAX_LCORE)) {
+        log_error("rte_get_next_lcore() error");
+        goto error_1;
+    }
+
     ret = rte_eal_remote_launch(server_process_rx, &sv, lcore_worker[0]);
     if (unlikely(ret < 0)) {
         log_error("rte_eal_remote_launch() error: %s",
@@ -956,6 +1058,13 @@ static int gateway(void)
         goto error_1;
     }
 
+    ret = rte_eal_remote_launch(dispatcher, NULL, lcore_worker[4]);
+    if (unlikely(ret < 0)) {
+        log_error("rte_eal_remote_launch() error: %s",
+                rte_strerror(-ret));
+        goto error_1;
+    }
+
     metrics_collect();
 
     ret = rte_eal_wait_lcore(lcore_worker[0]);
@@ -977,6 +1086,12 @@ static int gateway(void)
     }
 
     ret = rte_eal_wait_lcore(lcore_worker[3]);
+    if (unlikely(ret == -1)) {
+        log_error("rpc_server() error");
+        goto error_1;
+    }
+
+    ret = rte_eal_wait_lcore(lcore_worker[4]);
     if (unlikely(ret == -1)) {
         log_error("rpc_server() error");
         goto error_1;

--- a/src/include/io.h
+++ b/src/include/io.h
@@ -55,7 +55,8 @@ int set_nonblocking(int fd);
 int init_tenant_pipes(void);
 int write_pipe(struct http_transaction *txn);
 struct http_transaction* read_pipe(tenant_pipe *tp);
-int add_pipes_to_epoll(int epoll_fd, struct epoll_event *ev);
+int add_regular_pipe_to_epoll(int epoll_fd, struct epoll_event *ev, int pipe_fd);
+int add_weighted_pipes_to_epoll(int epoll_fd, struct epoll_event *ev);
 ssize_t read_full(int fd, void *buf, size_t count);
 
 int retry_connect(int sockfd, struct sockaddr *addr);

--- a/src/io_helper.c
+++ b/src/io_helper.c
@@ -147,7 +147,20 @@ int init_tenant_pipes(void) {
     return 0;
 }
 
-int add_pipes_to_epoll(int epoll_fd, struct epoll_event *ev) {
+int add_regular_pipe_to_epoll(int epoll_fd, struct epoll_event *ev, int pipe_fd) {
+    set_nonblocking(pipe_fd);
+    ev->events = EPOLLIN;
+    ev->data.fd = pipe_fd;
+
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, pipe_fd, ev) == -1) {
+        log_error("epoll_ctl(EPOLL_CTL_ADD): %s", strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+int add_weighted_pipes_to_epoll(int epoll_fd, struct epoll_event *ev) {
     for (int i = 0; i < cfg->n_tenants; i++) {
         set_nonblocking(tenant_pipes[i].fd[0]);
         ev->events = EPOLLIN;


### PR DESCRIPTION
The old design of SPRIGHT Gateway has multiple threads concurrent write access to the same socket via `io_tx()`. This may result in race condition and lower down performance under high load rate.

The solution in this improved version is to have a dedicated thread called *dispatcher* to have exclusive access to `io_tx()`. Other threads (as producer) want to use `io_tx()` has to be proxied by *dispatcher*. Each has a `pipe` to pass descriptors to the *dispatcher*; The *dispatcher* uses `epoll` to consume descriptors from the producer threads. The diagrams below show the difference bewteen old threading model and current improved threading model:

**Old threading model**:
<img width="1513" alt="Screenshot 2024-08-28 at 4 21 50 PM" src="https://github.com/user-attachments/assets/341f6ab2-aafd-4af1-b05e-93fb8eaeebe3">

**Improved threading model**:
<img width="1501" alt="Screenshot 2024-08-28 at 4 22 56 PM" src="https://github.com/user-attachments/assets/c0a0edd1-1dda-49ce-8da9-896d5fea8e04">